### PR TITLE
Add additional permission in service engine role

### DIFF
--- a/gcp-iam.tf
+++ b/gcp-iam.tf
@@ -100,6 +100,7 @@ resource "google_project_iam_custom_role" "serviceengine" {
     "compute.instances.setTags",
     "compute.instances.use",
     "compute.machineTypes.get",
+    "compute.machineTypes.list",
     "compute.regionOperations.get",
     "compute.regions.get",
     "compute.regions.list",

--- a/gcp-iam.tf
+++ b/gcp-iam.tf
@@ -60,6 +60,7 @@ resource "google_project_iam_custom_role" "network" {
     "compute.regions.get",
     "compute.routes.create",
     "compute.routes.delete",
+    "compute.routes.get",
     "compute.routes.list",
     "compute.subnetworks.get",
     "compute.subnetworks.list",


### PR DESCRIPTION
The permission 'compute.machineTypes.list' is necessary for the controller to populate the instance flavor drop-down when editing a service engine group.